### PR TITLE
Review notebook; script fix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,11 @@ jobs:
       - name: Set Up Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: uc-python-dl
+          activate-environment: uc-python
           environment-file: environment.yml
       - name: Set Up Jupyter Kernel
         run: |
-          python -m ipykernel install --user --name uc-python-dl
+          python -m ipykernel install --user --name uc-python
       - name: Install Papermill
         run: |
           conda install papermill

--- a/data/planes.csv
+++ b/data/planes.csv
@@ -1,0 +1,3323 @@
+tailnum,year,type,manufacturer,model,engines,seats,speed,engine
+N10156,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N102UW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N103US,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N104UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N10575,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N105UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N107US,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N108UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N109UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N110UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N11106,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11107,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11109,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11113,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11119,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11121,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11127,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11137,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11140,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11150,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11155,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11164,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11165,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11176,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11181,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11184,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11187,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11189,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11191,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11192,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11193,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11194,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N11199,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N111US,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N11206,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N112US,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N113UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N114UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N11535,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N11536,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N11539,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N11544,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N11547,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N11548,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N11551,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N11565,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N117UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N118US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N119US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N1200K,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1201P,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N12109,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N12114,1995.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N12116,1996.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N12122,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12125,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N12126,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12135,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12136,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12142,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12145,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12157,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12160,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12163,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12166,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12167,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12172,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12175,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12195,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N121DE,1987.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N121UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N12201,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N12216,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N12218,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N12221,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N12225,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N12238,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N122US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N123UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N124US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N12540,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12552,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12563,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12564,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12567,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12569,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N125UW,2009.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N126UW,2009.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N127UW,2010.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N128UW,2010.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N12900,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12921,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12922,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12924,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12957,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12967,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N12996,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13110,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N13113,1995.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N13118,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N13123,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N13124,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N13132,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N13133,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N13138,1999.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N13161,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N131EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N13202,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N13248,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N132EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N133EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N134EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N13538,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13550,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13553,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13566,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N135EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N136DL,1991.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N136EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N13716,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N13718,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N13750,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N137DL,1991.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N137EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N138EV,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N13903,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13908,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13913,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13914,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13949,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13955,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13956,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13958,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13964,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13965,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13968,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13969,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13970,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13975,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13978,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13979,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13988,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13989,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13992,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13994,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13995,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N13997,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14102,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N14105,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14106,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N14107,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N14115,1995.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N14116,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14117,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14118,1997.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N14120,1997.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N14121,1997.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N14125,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14143,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14148,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14153,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14158,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14162,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14168,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14171,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14173,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14174,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14177,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14179,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14180,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14186,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14188,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14198,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14203,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14204,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N14214,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N14219,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N14228,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N14230,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N14231,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N14237,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N14242,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N14250,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N143DA,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N14542,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14543,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14558,,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14562,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14568,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14570,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14573,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14629,1965.0,Fixed wing multi engine,BOEING,737-524,2,149,,Turbo-fan
+N146PQ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N14704,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N14731,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N147PQ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N14902,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14904,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14905,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14907,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14916,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14920,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14923,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14950,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14952,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14953,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14959,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14960,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14972,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14974,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14977,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14991,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14993,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N14998,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N1501P,1990.0,Fixed wing multi engine,BOEING,767-3P6,2,290,,Turbo-fan
+N150UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N151UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N152DL,1990.0,Fixed wing multi engine,BOEING,767-3P6,2,290,,Turbo-fan
+N152UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N153DL,1990.0,Fixed wing multi engine,BOEING,767-3P6,2,290,,Turbo-fan
+N153PQ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N153UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N154DL,1991.0,Fixed wing multi engine,BOEING,767-3P6,2,290,,Turbo-fan
+N154UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N15555,,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15572,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15574,,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N155DL,1991.0,Fixed wing multi engine,BOEING,767-3P6,2,290,,Turbo-fan
+N155UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N156DL,1991.0,Fixed wing multi engine,BOEING,767-3P6,2,290,,Turbo-fan
+N156UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N15710,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N15712,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N157UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N15910,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15912,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15973,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15980,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15983,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15985,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N15986,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N1602,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1603,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1604R,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1605,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N16065,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1607B,2000.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1608,2000.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1609,2000.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1610D,2000.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N16112,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N1611B,2000.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1612T,2001.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N1613B,2001.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N16147,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N16149,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N16151,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N16170,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N16178,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N16183,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N161PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N161UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N16217,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N16234,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N162PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N162UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N163US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N16541,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16546,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16559,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16561,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16571,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N165US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N166PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N16701,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N16703,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N16709,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N16713,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N16732,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N167US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N168AT,2004.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N16911,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16918,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16919,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16951,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16954,1998.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16961,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16963,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16976,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16981,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16987,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N16999,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N169AT,2004.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N169DZ,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N169UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N170PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N170US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N17104,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N17105,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N17108,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N17115,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N17122,1997.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N17126,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N17128,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N17133,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N17138,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N17139,2000.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N17146,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N17159,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N17169,2004.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N17185,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N17196,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N171DN,1990.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N171DZ,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N171US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N17229,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N17233,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N17244,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N17245,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N172DN,1990.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N172DZ,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N172US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N173AT,2004.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N173DZ,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N173US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N174AT,2004.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N174DN,1990.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N174DZ,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N174US,,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N17560,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N175AT,2004.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N175DN,1990.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N175DZ,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N176AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N176DN,1990.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N176DZ,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N176PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N176UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N17719,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N17730,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N177DN,1991.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N177DZ,1999.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N177US,,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N178DN,1991.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N178DZ,2000.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N178JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N178US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N17984,2000.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N179DN,1991.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N179JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N179UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N180DN,1992.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N180US,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N18101,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N18102,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N18112,1995.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N18114,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N18119,1997.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N18120,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N181DN,1992.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N181PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N181UW,,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N18220,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N18223,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N18243,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N182DN,1992.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N182UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N183DN,1993.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N183JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N183UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N184AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N184DN,1993.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N184JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N184US,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N18556,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N18557,,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N185DN,1995.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N185UW,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N186DN,1995.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N186PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N186US,2002.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N187DN,1996.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N187JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N187PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N187US,2002.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N188DN,1996.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N188US,2002.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N189DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N189UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N190DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N190JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N190UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N19117,1996.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N19130,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N19136,1999.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N19141,2000.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N191DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N191UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N192DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N192JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N192UW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-211,2,199,,Turbo-jet
+N193DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N193JB,2005.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N193UW,2008.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N194DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N194UW,,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N19554,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N195DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N195PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N195UW,2008.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N196DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N196UW,2009.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N197DN,1997.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N197JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N197PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N197UW,2009.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N198DN,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N198JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N198UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N19966,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N199DN,1998.0,Fixed wing multi engine,BOEING,767-332,2,330,,Turbo-fan
+N199UW,2013.0,Fixed wing multi engine,AIRBUS,A321-211,2,199,,Turbo-fan
+N200PQ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N200WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N201AA,1959.0,Fixed wing single engine,CESSNA,150,1,2,90.0,Reciprocating
+N201FR,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N201LV,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N202AA,1980.0,Fixed wing multi engine,CESSNA,421C,2,8,90.0,Reciprocating
+N202FR,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N202WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N203FR,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N203JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N203WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N204FR,2004.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N204WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N205FR,2010.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N205WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N206FR,2010.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N206JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N206UA,1999.0,Fixed wing multi engine,BOEING,777-222,2,400,,Turbo-fan
+N206WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N207FR,2010.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N207WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N208FR,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N208WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N20904,2012.0,Fixed wing multi engine,BOEING,787-8,2,260,,Turbo-fan
+N209FR,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N209WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N210FR,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N210WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N21108,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N21129,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N21130,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N21144,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N21154,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N21197,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N211FR,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N211WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N212WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N213FR,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N213WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N214FR,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N214WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N21537,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N215WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N216FR,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N216JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N216WR,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N21723,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N217JC,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N218FR,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-214,2,182,,Turbo-fan
+N218WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N219WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N220WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N221FR,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N221WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N222WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N223WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N224WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N225WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N226WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N227WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N228JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N228PQ,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N228UA,2002.0,Fixed wing multi engine,BOEING,777-222,2,400,,Turbo-fan
+N228WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N22909,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N22971,1999.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N229JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N229WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N230WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N23139,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N231JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N231WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N232PQ,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N232WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N233LV,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N234WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N235WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N236JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N236WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N23707,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N23708,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N23721,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N237WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N238JB,,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N238WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N239JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N239WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N240AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N240WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N24103,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N24128,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N241WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N24202,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N24211,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N24212,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N24224,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N242WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N243WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N244WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N245AY,1987.0,Fixed wing multi engine,BOEING,767-201,2,255,,Turbo-jet
+N245WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N246LV,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N24702,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N24706,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N24715,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N24729,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N247JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N247WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N248WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N249JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N249WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N250WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N25134,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N251WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N252WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N253WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N254WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N255WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N256WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N25705,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N257WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N258JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N258WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N259WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N260WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N26123,1997.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N26141,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N261AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N261WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N26208,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N26210,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N26215,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N26226,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N262WN,2006.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N263WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N264LV,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N26545,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N26549,2002.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N265JB,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N265WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N266JB,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N266WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N267JB,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N267WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N268WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N26906,2012.0,Fixed wing multi engine,BOEING,787-8,2,260,,Turbo-fan
+N269WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N270WN,1998.0,Fixed wing multi engine,BOEING,737-705,2,149,,Turbo-fan
+N27152,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N27190,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N271LV,,Fixed wing multi engine,BOEING,737-705,2,149,,Turbo-fan
+N27200,2006.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N27205,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N27213,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N27239,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N272AT,,Fixed wing multi engine,BOEING,777-200,2,400,,Turbo-jet
+N272PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N272WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N273AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N273JB,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N273WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N27421,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N27477,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N274JB,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N274WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N275WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N276AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N276WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N27722,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N27724,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N27733,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N277WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N278AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N278WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N27901,2012.0,Fixed wing multi engine,BOEING,787-8,2,260,,Turbo-fan
+N27962,1999.0,Fixed wing multi engine,EMBRAER,EMB-145,2,55,,Turbo-jet
+N279AT,2005.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N279JB,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N279PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N279WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N280WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N281AT,,Fixed wing multi engine,AIRBUS INDUSTRIE,A340-313,4,375,,Turbo-jet
+N281JB,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N281WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N282WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N283JB,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N283WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N28457,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N28478,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N284AT,2006.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N284JB,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N284WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N285AT,2006.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N285WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N286WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N287AT,2006.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N287WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N288WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N289AT,2006.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N289CT,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N290WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N29124,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N29129,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N291AT,2006.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N291WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N292JB,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N292PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N292WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N293PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N293WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N294JB,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N294PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N294WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N295AT,2006.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N295PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N295WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N296JB,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N296PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N296WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N29717,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N297PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N297WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N298JB,2009.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N298PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N298WN,,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N29906,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N29917,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N299AT,2006.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N299PQ,2013.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N299WN,,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N301DQ,,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N301NB,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N302AS,2003.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N302DQ,2008.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N302NB,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N303AS,2001.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N303DQ,2008.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N30401,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N304DQ,2008.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N304JB,2009.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N305AS,2001.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N305DQ,2008.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N306AS,2001.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N306DQ,2009.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N306JB,2009.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N307AS,2001.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N307DQ,2009.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N307JB,2009.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N308DE,,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N309AS,2001.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N309AT,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N309DE,2009.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N309JB,2009.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N309US,1990.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N310DE,2009.0,Fixed wing multi engine,BOEING,737-732,2,149,,Turbo-fan
+N310NW,1990.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N31131,2003.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N311US,1990.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N312US,1990.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N313US,1990.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N31412,2002.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N314NB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N314US,1991.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N315AS,2002.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N315AT,,Fixed wing single engine,JOHN G HESS,AT-5,1,2,,4 Cycle
+N315NB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N315US,1991.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N316JB,2009.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N316NB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N316US,1991.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N317JB,2010.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N317NB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N317US,1991.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N317WN,1988.0,Fixed wing multi engine,BOEING,737-3Q8,2,149,,Turbo-fan
+N318AS,2003.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N318JB,2010.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N318NB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N318US,1991.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N319AA,1985.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N319AS,2003.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N319NB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N319US,1991.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N320AA,1985.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N320AS,2003.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N320NB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N320US,1991.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N321NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N321US,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N322NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N322US,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N323AA,1986.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N323AS,2004.0,Fixed wing multi engine,BOEING,737-990,2,149,,Turbo-jet
+N323JB,2010.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N323NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N323US,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N32404,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N324AA,1986.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N324JB,2010.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N324NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N324US,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N325AA,1986.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N325NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N325US,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N326AT,2007.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N326NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N326US,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N327AA,1986.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N327NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N327NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N328AA,1986.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N328JB,2011.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N328NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N328NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N329AA,1987.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N329JB,2011.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N329NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N329NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N330AT,2007.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N330NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N330NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N33103,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N33132,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N33182,2005.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N331NB,,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N331NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N33203,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33209,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33262,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33264,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33266,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33284,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33286,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33289,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33292,,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N33294,2005.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N332AA,1987.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N332NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N332NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N333NB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N333NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-211,2,182,,Turbo-jet
+N334JB,2011.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N334NB,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N334NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N335AA,1987.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N335NB,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N335NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N336AA,1987.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N336AT,2008.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N336NB,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N336NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N33714,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N337JB,2011.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N337NB,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-114,2,145,,Turbo-fan
+N337NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N338AA,1987.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N338AT,2008.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N338NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N338NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N339AA,1988.0,Fixed wing multi engine,BOEING,767-223,2,255,,Turbo-fan
+N339JB,2011.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N339NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N339NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N340LV,1987.0,Fixed wing multi engine,BOEING,737-3K2,2,149,,Turbo-jet
+N340NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N340NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N34110,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N34111,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N34131,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N34137,1999.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N341NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N341NW,1992.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N34222,1998.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N34282,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N342NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N342NW,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N343NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N343NW,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N34455,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N34460,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N344AA,1992.0,Fixed wing multi engine,GULFSTREAM AEROSPACE,G-IV,2,22,,Turbo-fan
+N344NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N344NW,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N344SW,1989.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N345NB,,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N345NW,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N345SA,1987.0,Fixed wing multi engine,BOEING,737-3K2,2,149,,Turbo-jet
+N346JB,2011.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N346NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N346SW,1989.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N347AA,1985.0,Rotorcraft,SIKORSKY,S-76A,2,14,,Turbo-shaft
+N347NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N347NW,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N347SW,1989.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N348JB,2012.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N348NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N348NW,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N349NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N349NW,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N349SW,1989.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N350AA,1980.0,Fixed wing multi engine,PIPER,PA-31-350,2,8,162.0,Reciprocating
+N350NA,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N350SW,1989.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N351AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N351JB,2012.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N351NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N351NW,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N35204,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N35260,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N35271,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N352AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N352NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N352NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N352SW,1990.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N353AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N353AT,2009.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N353JB,2012.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N353NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N353NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N353SW,1990.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N35407,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N354AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N354JB,2013.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N354NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N354NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N354SW,1991.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N355AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N355JB,2013.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N355NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N355NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N355SW,1991.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N356NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N356SW,1991.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N357AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N357NB,2002.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N357NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N357SW,1992.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N358AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N358JB,2013.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N358NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N358NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N358SW,1992.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N359AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N359NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N359NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N359SW,1992.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N360AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N360NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N360NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N360SW,1992.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N361AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N361NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N361NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N361SW,1992.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N361VA,2013.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N36207,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N36247,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N36272,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N36280,2003.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N362AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N362NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N362NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N362SW,1992.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N363AA,1988.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N363NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N363NW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N363SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N36444,2010.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N36447,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N36469,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N36472,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N36476,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N364AA,1973.0,Fixed wing multi engine,CESSNA,310Q,2,6,167.0,Reciprocating
+N364NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N364NW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N364SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N365AA,2001.0,Rotorcraft,AGUSTA SPA,A109E,2,8,,Turbo-shaft
+N365NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N365NW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N365SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N366AA,1991.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N366NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N366NW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N366SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N367NW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N367SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N368AA,1991.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N368JB,2013.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N368NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N368NW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N368SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N36915,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N369AA,1992.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N369NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N369NW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N369SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N370AA,1992.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N370NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N370NW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N370SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N371AA,1992.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N371CA,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N371DA,1998.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N371NB,2003.0,Fixed wing multi engine,AIRBUS,A319-114,2,145,,Turbo-fan
+N371NW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N371SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N37252,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37253,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37255,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37263,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37267,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37273,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37274,2002.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37277,2002.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37281,2003.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37287,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37290,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37293,2005.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N37298,2005.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N372AA,1992.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N372DA,1998.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N372NW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N372SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N3730B,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3731T,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3732J,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3733Z,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3734B,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3735D,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3736C,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3737C,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3738B,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3739P,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N373AA,1992.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N373DA,1998.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N373JB,2013.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N373NW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N373SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N37408,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N37409,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N3740C,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N37413,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37419,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N3741S,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N37420,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37422,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37427,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N3742C,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N37434,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37437,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N3743H,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3744F,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N37456,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N3745B,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N37462,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37464,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37465,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37466,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37468,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N3746H,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N37470,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37471,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N37474,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N3747D,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3748Y,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3749D,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N374AA,1992.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N374DA,1998.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N374JB,2013.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N374NW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-212,2,182,,Turbo-fan
+N374SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N3750D,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3751B,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3752,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3753,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3754A,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3755D,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3756,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3757D,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3758Y,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3759,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N375DA,1998.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N375JB,2013.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N375NC,2002.0,Fixed wing multi engine,AIRBUS,A320-212,2,182,,Turbo-fan
+N375SW,1993.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N3760C,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3761R,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3762Y,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3763D,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3764D,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3765,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3766,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3767,2001.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3768,2002.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3769L,2002.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N376AA,1978.0,Fixed wing single engine,PIPER,PA-32RT-300,1,7,,Reciprocating
+N376DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N376NW,2002.0,Fixed wing multi engine,AIRBUS,A320-212,2,182,,Turbo-fan
+N376SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N37700,2002.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3771K,2002.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N3772H,2010.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-fan
+N3773D,2010.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-fan
+N377AA,,Fixed wing single engine,PAIR MIKE E,FALCON XP,1,2,,Reciprocating
+N377DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N377NW,2003.0,Fixed wing multi engine,AIRBUS,A320-211,2,182,,Turbo-fan
+N378AA,1963.0,Fixed wing single engine,CESSNA,172E,1,4,105.0,Reciprocating
+N378DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N378NW,2003.0,Fixed wing multi engine,AIRBUS,A320-211,2,182,,Turbo-fan
+N378SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N379AA,1993.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N379DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N379SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N380DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N380HA,2010.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N380SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N381AA,1956.0,Fixed wing multi engine,DOUGLAS,DC-7BF,4,102,232.0,Reciprocating
+N381DN,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N381HA,2010.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N38257,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N38268,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N382DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N382HA,2010.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N382SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N383AA,1972.0,Fixed wing multi engine,BEECH,E-90,2,10,,Turbo-prop
+N383DN,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N383HA,2011.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N383SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N38403,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N38417,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38424,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38443,2010.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38446,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38451,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38454,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38458,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38459,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38467,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N38473,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N384AA,1993.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N384DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N384HA,2011.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N384SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N385DN,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N385HA,2012.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N386AA,1994.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N386DA,1999.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N386HA,2012.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N386SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N38727,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N387DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N387SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N388AA,1995.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N388DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N388HA,2012.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N388SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N389AA,1995.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N389DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N389HA,,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N389SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N390AA,1995.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N390DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N390HA,2013.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N390SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N391AA,1995.0,Fixed wing multi engine,BOEING,767-323,2,330,,Turbo-fan
+N391CA,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N391DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N391HA,2013.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N391SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N39297,2005.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N392DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N392HA,2013.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N392SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N393AA,1994.0,Rotorcraft,BELL,230,2,11,,Turbo-shaft
+N393DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N393HA,2013.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N39415,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N39416,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N39418,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N39423,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N39450,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N39461,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N39463,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N39475,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N394AA,2007.0,Fixed wing single engine,AVIAT AIRCRAFT INC,A-1B,1,2,,Reciprocating
+N394DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N394DL,1995.0,Fixed wing multi engine,BOEING,767-324,2,269,,Turbo-fan
+N394SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N395DN,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N395HA,2013.0,Fixed wing multi engine,AIRBUS,A330-243,2,377,,Turbo-fan
+N395SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N396DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N396SW,1994.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N39726,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N39728,1999.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N397AA,1985.0,Fixed wing single engine,STEWART MACO,FALCON XP,1,2,,Reciprocating
+N397DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N397SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N398AA,,Fixed wing multi engine,LEARJET INC,60,2,11,,Turbo-fan
+N398CA,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N398DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N398SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N399DA,2000.0,Fixed wing multi engine,BOEING,737-832,2,189,,Turbo-jet
+N399WN,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N400WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N401UA,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N401WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N402AS,2012.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N402UA,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N402WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N403AS,2012.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N403UA,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N403WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N404UA,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N404WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N405UA,1993.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N405WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N406UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N406US,1988.0,Fixed wing multi engine,BOEING,737-401,2,149,,Turbo-jet
+N406WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N407AS,2012.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N407UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N407WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N408AS,2012.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N408UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N408WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N409AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N409UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N409US,1988.0,Fixed wing multi engine,BOEING,737-401,2,149,,Turbo-jet
+N409WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N410UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N410WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N41104,2002.0,Fixed wing multi engine,EMBRAER,EMB-145XR,2,55,,Turbo-fan
+N41135,1999.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N41140,2000.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N411UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N411WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N412UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N412WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N413AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N413UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N413WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N414UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N414WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N415UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N415WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N416UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N416WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N417UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N417WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N418UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N418WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N419AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N419UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N419US,1989.0,Fixed wing multi engine,BOEING,737-401,2,149,,Turbo-jet
+N419WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N420UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N420US,1989.0,Fixed wing multi engine,BOEING,737-401,2,149,,Turbo-jet
+N420WN,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N421LV,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N421UA,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N422UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N422WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N423AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N423UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N423WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N424AA,1986.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N424UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N424WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N425AA,1968.0,Fixed wing single engine,PIPER,PA-28-180,1,4,107.0,Reciprocating
+N425LV,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N425UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N426AA,1986.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N426UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N426WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N427SW,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N427UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N427US,1989.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N427WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N428UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N428WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N429UA,1995.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N429WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N430UA,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N430US,1989.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N430WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N431AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N431UA,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N431WN,2002.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N432UA,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N432US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N432WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N433AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N433AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N433LV,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N433UA,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N433US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N434AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N434UA,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N434US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N434WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N435AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N435AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N435UA,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N435US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N435WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N436AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N436UA,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N436WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N437AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N437UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N437WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N438AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N438UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N438US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N438WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N439AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N439UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N439US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N439WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N440AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N440LV,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N440UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N440US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N441UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N441US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N441WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N442AS,2013.0,Fixed wing multi engine,BOEING,737-990ER,2,222,,Turbo-fan
+N442UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N442WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N443UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N443US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N443WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N444UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N444US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N444WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N445UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N445WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N446UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N446WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N447UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N447WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N448UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N448WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N449UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N449US,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N449WN,2003.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N450UW,1990.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N450WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N451UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N451WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N452UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N452UW,1991.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N452WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N453UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N453UW,1991.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N453WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N45440,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N454AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N454UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N454WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N455AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N455UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N455UW,1991.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N455WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N456AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N456UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N456WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N457UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N457WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N458UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N458WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N45905,2012.0,Fixed wing multi engine,BOEING,787-8,2,260,,Turbo-fan
+N459UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N459WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N460UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N460UW,1991.0,Fixed wing multi engine,BOEING,737-4B7,2,149,,Turbo-fan
+N460WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N461UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N461WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N462UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N462WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N463UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N463WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N464UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N464WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N465UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N465WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N466AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N466UA,,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N466WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N467AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N467UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N467WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N468AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N468UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N468WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N469AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N469UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N469WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N470AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N470UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N470WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N471AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N471UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N472AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N472UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N472WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N473AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N473UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N473WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N47414,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N474UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N474WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N475AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N475UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N475WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N476AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N476UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N476WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N477AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N477UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N477WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N478AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N478UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N478WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N479AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N479UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N479WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N480AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N480UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N480WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N48127,1998.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N481AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N481UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N481WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N482AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N482UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N482WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N483UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N483WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N484AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N484UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N484WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N485AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N485UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N485WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N486AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N486UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N486WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N487AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N487UA,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N487WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N488AA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N488UA,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N488WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N48901,2001.0,Fixed wing multi engine,EMBRAER,EMB-145LR,2,55,,Turbo-fan
+N489AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N489UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N489WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N490AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N490UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N490WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N491AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N491UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N491WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N492AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N492UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N492WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N493AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N493UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N493WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N494AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N494UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N494WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N495UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N495WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N496AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N496UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N496WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N497UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N497WN,2004.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N498UA,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N498WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N499AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N499WN,2005.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N501AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N501MJ,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N501US,1985.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N502MJ,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N502UA,1989.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N503JB,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N503MJ,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N503UA,1989.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N503US,1985.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N504JB,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N504MJ,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N504UA,1989.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N505AA,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N505JB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N505MJ,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N505SW,1990.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N505UA,1989.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N506AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N506JB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N506MJ,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N507AY,2008.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N507MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N507US,1985.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N508AA,1975.0,Rotorcraft,BELL,206B,1,5,112.0,Turbo-shaft
+N508AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N508AY,2008.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N508JB,2007.0,Fixed wing single engine,CIRRUS DESIGN CORP,SR22,1,4,,Reciprocating
+N508MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N508SW,1990.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N508UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N509AY,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N509JB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N509MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N509SW,1990.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N509UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N510JB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N510MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N510SW,1990.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N510UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N510UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N511MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N511SW,1991.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N511UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N512AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N512MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N512SW,1991.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N512UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N513AA,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N513AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N513MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N513UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N514AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N514MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N514SW,1991.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N514UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N515MJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N515SW,1991.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N515UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N516AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N516JB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N516LR,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N516UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N517AA,,Fixed wing single engine,HURLEY JAMES LARRY,FALCON-XP,1,2,,Reciprocating
+N517AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N517JB,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N517UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N518AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N518LR,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N518UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N519AA,1979.0,Fixed wing multi engine,CESSNA,550,2,8,,Turbo-fan
+N519AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N519JB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N519LR,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N519MQ,1983.0,Fixed wing single engine,CESSNA,A185F,1,6,127.0,Reciprocating
+N519UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N519US,1986.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N519UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N520AA,1985.0,Fixed wing single engine,KILDALL GARY,FALCON-XP,1,2,,Reciprocating
+N520AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N520JB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N520UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N520UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N521AA,,Fixed wing single engine,STEWART MACO,FALCON-XP,1,2,,Reciprocating
+N521JB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N521LR,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N521SW,1991.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N521UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N521US,1986.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N521UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N521VA,2006.0,Fixed wing multi engine,AIRBUS,A319-115,2,147,,Turbo-fan
+N522LR,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N522SW,1992.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N522UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N522US,1987.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N522VA,2006.0,Fixed wing multi engine,AIRBUS,A319-115,2,147,,Turbo-fan
+N523AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N523JB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N523SW,1992.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N523UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N523US,1987.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N523UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N523VA,2007.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N524AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N524JB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N524SW,1992.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N524UA,1990.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N524UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N524VA,2007.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N525AA,1980.0,Fixed wing multi engine,PIPER,PA-31-350,2,8,162.0,Reciprocating
+N525AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N525SW,1992.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N525US,1987.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N525VA,2007.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N526AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N526SW,1992.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N526UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N526VA,2008.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N527AS,,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N527SW,1992.0,Fixed wing multi engine,BOEING,737-5H4,2,149,,Turbo-jet
+N527VA,2008.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N528AA,,Fixed wing single engine,LAMBERT RICHARD,FALCON XP,1,2,,Reciprocating
+N528AS,2009.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N528UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N528VA,2008.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N529AS,2010.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N529JB,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N529UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N529VA,2008.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N530AS,2010.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N530UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N530US,1988.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N530VA,2008.0,Fixed wing multi engine,AIRBUS,A319-115,2,147,,Turbo-fan
+N531AS,2010.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N531JB,,Fixed wing single engine,BARKER JACK L,ZODIAC 601HDS,1,2,,Reciprocating
+N531US,1988.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N532AS,2010.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N532US,1988.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N533AS,2011.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N533UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N533US,1988.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N53441,,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N53442,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N534AS,2011.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N534JB,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N534UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N534US,1988.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N534UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N535AS,2011.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N535JB,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N535UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N535UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N536AA,,Fixed wing single engine,AMERICAN AIRCRAFT INC,FALCON XP,1,2,,Reciprocating
+N536AS,2012.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N536JB,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N536UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N536UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N537AS,2012.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N537JB,2012.0,Rotorcraft,ROBINSON HELICOPTER CO,R66,1,5,,Turbo-shaft
+N537UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N537UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N538AS,2012.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N538CA,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N538UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N538UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N539UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N539US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N539UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N540AA,,Fixed wing single engine,AMERICAN AIRCRAFT INC,FALCON XP,1,2,,Reciprocating
+N540US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N540UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N541UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N541US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N541UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N54241,1999.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N542US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N542UW,2009.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N543UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N543US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N543UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N544AA,2007.0,Fixed wing single engine,FRIEDEMANN JON,VANS AIRCRAFT RV6,1,2,,Reciprocating
+N544UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N544UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N545AA,1976.0,Fixed wing single engine,PIPER,PA-32R-300,1,7,126.0,Reciprocating
+N545UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N545UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N546AS,2005.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N546UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N546UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N54711,1998.0,Fixed wing multi engine,BOEING,737-724,2,149,,Turbo-jet
+N547JB,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N547UA,1991.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N547US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N547UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N548AS,2005.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N548UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N548US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N548UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N549AS,2005.0,Fixed wing multi engine,BOEING,737-8FH,2,149,,Turbo-jet
+N549UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N549US,1996.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N549UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N550NW,2001.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N550UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N550UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N550WN,2001.0,Fixed wing multi engine,BOEING,737-76Q,2,149,,Turbo-fan
+N551AA,1985.0,Fixed wing single engine,LEBLANC GLENN T,FALCON XP,1,2,,Reciprocating
+N551AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N551NW,2001.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N551UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N551UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N551WN,2001.0,Fixed wing multi engine,BOEING,737-76Q,2,149,,Turbo-fan
+N552AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N552AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N552JB,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N552NW,2001.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N552UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N552UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N552WN,2002.0,Fixed wing multi engine,BOEING,737-7BX,2,149,,Turbo-fan
+N553AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N553AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N553NW,2001.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N553UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N553UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N553WN,2002.0,Fixed wing multi engine,BOEING,737-7BX,2,149,,Turbo-fan
+N554AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N554JB,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N554NW,2001.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N554UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N554UW,2011.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N554WN,2002.0,Fixed wing multi engine,BOEING,737-7BX,2,149,,Turbo-fan
+N555AY,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N555LV,2011.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N555NW,2002.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N555UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N556AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N556AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N556JB,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N556NW,2002.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N556UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N556UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N556WN,2011.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N557AA,1993.0,Fixed wing single engine,MARZ BARRY,KITFOX IV,1,2,,Reciprocating
+N557AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N557NW,2002.0,Fixed wing multi engine,BOEING,757-251,2,178,,Turbo-jet
+N557UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N557UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N558AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N558AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N558JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N558UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N558UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N559AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N559AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N559JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N559UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N559UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N560AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N560AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N560UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N560UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N561AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N561JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N561UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N561UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N562AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N562JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N562UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N562UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N563AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N563JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N563UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N563UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N564AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N564AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N564JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N564UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N564UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N565AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N565AS,2006.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N565JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N565UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N565UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N566AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N566AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N566JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N566UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N566UW,2012.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N567AA,1959.0,Fixed wing single engine,DEHAVILLAND,OTTER DHC-3,1,16,95.0,Reciprocating
+N567UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N567UW,2013.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N56859,2004.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N568AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N568AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N568JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N568UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N568UW,2013.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N569AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N569AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N569JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N569UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N569UW,2013.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N57016,2000.0,Fixed wing multi engine,BOEING,777-224,2,400,,Turbo-fan
+N570AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N570AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N570JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N570UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N570UW,2013.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N57111,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N571AA,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N571JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N571UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N571UW,2013.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N572UW,2013.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-231,2,379,,Turbo-fan
+N573AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N573UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N57439,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N574AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N574UA,1992.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N575AA,1963.0,Fixed wing single engine,CESSNA,210-5(205),1,6,,Reciprocating
+N575UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N576AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N576UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N577AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N577UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N57852,2001.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N57855,2004.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N57857,2004.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N57862,2001.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N57863,2001.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N57864,2001.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N57868,2002.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N57869,2002.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N57870,2003.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N578AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N578UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N579AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N579JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N579UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N580JB,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N580UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N58101,1994.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N581AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N581AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N582AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N582CA,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N583AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N583AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N583JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N584AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N584AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N584JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N585AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N585AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N585JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N585UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N586AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N586AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N586JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N587AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-82(MD-82),2,172,,Turbo-fan
+N587AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N587JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N587NW,2002.0,Fixed wing multi engine,BOEING,757-351,2,275,,Turbo-jet
+N587UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N588JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N588UA,1993.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N589AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N589AS,2007.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N589JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N589UA,1997.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N59053,2000.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N590AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N590AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N590JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N590NW,2003.0,Fixed wing multi engine,BOEING,757-351,2,275,,Turbo-jet
+N590UA,1997.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N591AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N591JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N592AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N592AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N592JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N593AA,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N593AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N593JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N594AA,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N594AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N594JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N594NW,2003.0,Fixed wing multi engine,BOEING,757-351,2,275,,Turbo-jet
+N594UA,1996.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N595AA,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N595JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N595NW,2003.0,Fixed wing multi engine,BOEING,757-351,2,275,,Turbo-jet
+N595UA,1998.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N596AA,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N596AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N596UA,1998.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N597AA,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N597AS,2008.0,Fixed wing multi engine,BOEING,737-890,2,149,,Turbo-fan
+N597JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N597UA,1998.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N598AA,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N598JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N598UA,1999.0,Fixed wing multi engine,BOEING,757-222,2,178,,Turbo-jet
+N599AA,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-83(MD-83),2,172,,Turbo-fan
+N599JB,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N600LR,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N600QX,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N600TR,1979.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N600WN,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N601AW,2003.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N601LR,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N601WN,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N601XJ,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N602AW,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N602DL,1984.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N602LR,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N602SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N602XJ,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N603AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N603DL,1984.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N603JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N603SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N604AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N604DL,1984.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N604LR,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N604QX,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N604SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N605JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N605LR,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N605QX,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N605SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N606JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N606LR,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N606SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N607AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N607JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N607LR,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N607SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N608AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N608DA,1985.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N608JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N608QX,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N608SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N609DL,1985.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N609SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N610DL,1985.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N610WN,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N611QX,,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N611SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N612AA,1989.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N612DL,1985.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N612JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N612QX,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N612SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N613AA,1989.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N613DL,1985.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N613JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N613SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N614DL,1985.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N614QX,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N614SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N615AA,1967.0,Fixed wing multi engine,BEECH,65-A90,2,9,202.0,Turbo-prop
+N615DL,1986.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N615JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N615QX,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N615SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N616DL,1986.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N616SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N617DL,1986.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N617SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N618AA,1989.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N618DL,1986.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N618JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N618WN,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N619AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N619SW,1995.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N620SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N621AA,1975.0,Fixed wing single engine,CESSNA,172M,1,4,108.0,4 Cycle
+N621JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N621SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N621VA,2006.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N622AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N622AW,1989.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N622SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N622VA,2006.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N623AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N623DL,1987.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N623JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N623SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N623VA,2006.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N624AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N624AG,1993.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N624AW,1989.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N624JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N624SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N624VA,2006.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N625AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N625AW,1989.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N625JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N625SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N625VA,2006.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N626AW,1989.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N626SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N626VA,2006.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N627AW,1989.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N627DL,1987.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N627JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N627SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N627VA,2006.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N628AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N628SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N628VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N629JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N629SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N629VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N630AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N630JB,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N630VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N630WN,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N631AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N631AW,1990.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N631VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N632AW,1989.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N632JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N632SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N632VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N633AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N633AW,1989.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-231,2,182,,Turbo-jet
+N633DL,1987.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N633JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N633SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N633VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N634AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N634JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N634SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N634VA,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N635AA,1990.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N635DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N635JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N635SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N635VA,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N636DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N636JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N636VA,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N636WN,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N637DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N637JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N637SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N637VA,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N638DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N638JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N638SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N638VA,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N639AA,1991.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N639DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N639JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N639SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N639VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N640AW,1994.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N640DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N640JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N640SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N640VA,2007.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N641DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N641JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N641SW,1996.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N641UA,1991.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N641VA,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N642AA,1991.0,Fixed wing multi engine,BOEING,757-223,2,178,,Turbo-fan
+N642AW,1996.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N642DL,1988.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N642VA,2008.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N642WN,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N643DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N643JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N643SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N644DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N644JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N644SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N644UA,1991.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N645DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N645JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N645SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N646DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N646JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N646SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N646UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N647AW,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N647DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N647SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N647UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N64809,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N648AW,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N648DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N648JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N648SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N648UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N649AW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N649DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N649JB,2006.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N649SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N649UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N650AW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N650DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N650SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N651AW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N651DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N651JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N651SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N651UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N652AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N652DL,1989.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N652JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N652SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N652UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N653AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N653JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N653SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N653UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N654AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N654DL,1990.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N654SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N654UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N655AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N655DL,1990.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N655JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N655UA,1992.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N655WN,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N656AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N656JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N656SW,1997.0,Fixed wing multi engine,BOEING,737-3H4,2,149,,Turbo-fan
+N656UA,1993.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N657AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N657JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N657SW,1985.0,Fixed wing multi engine,BOEING,737-3L9,2,149,,Turbo-fan
+N657UA,1993.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N658AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N658DL,1990.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N658JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N658SW,1985.0,Fixed wing multi engine,BOEING,737-3L9,2,149,,Turbo-fan
+N658UA,1993.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N659AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N659DL,1990.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N659JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N659SW,1985.0,Fixed wing multi engine,BOEING,737-301,2,149,,Turbo-fan
+N659UA,1993.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N66051,2000.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N66056,2001.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N66057,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N660AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N660DL,1990.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N660SW,1985.0,Fixed wing multi engine,BOEING,737-301,2,149,,Turbo-fan
+N660UA,1993.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N661AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N661DN,1990.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N661JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N661UA,1993.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N662AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N662DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N662JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N662SW,1985.0,Fixed wing multi engine,BOEING,737-3Q8,2,149,,Turbo-fan
+N663AW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N663DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N663JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N663SW,1985.0,Fixed wing multi engine,BOEING,737-3Q8,2,149,,Turbo-fan
+N663UA,1993.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N664AW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N664DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N664UA,1998.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N665AW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N665DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N665JB,2007.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N665UA,1998.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N665WN,1986.0,Fixed wing multi engine,BOEING,737-3Y0,2,149,,Turbo-fan
+N666DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N666UA,1998.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N667AW,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A320-232,2,200,,Turbo-fan
+N667DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N667UA,1998.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N66803,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N66808,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N668AW,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N668DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N668UA,1999.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N669AW,2002.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N669DN,1991.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N669SW,1987.0,Fixed wing multi engine,BOEING,737-3A4,2,149,,Turbo-jet
+N669UA,1999.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N6700,1999.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6701,1999.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6702,1999.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6703D,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6704Z,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N67052,2000.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N67058,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N6705Y,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6706Q,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6707A,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6708D,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6709,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N670DN,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N670SW,1988.0,Fixed wing multi engine,BOEING,737-3G7,2,149,,Turbo-jet
+N670UA,,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N670US,1990.0,Fixed wing multi engine,BOEING,747-451,4,450,,Turbo-jet
+N6710E,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6711M,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6712B,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N67134,1999.0,Fixed wing multi engine,BOEING,757-224,2,178,,Turbo-jet
+N6713Y,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6714Q,2000.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6715C,2001.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N6716C,2001.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N67171,2001.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N671DN,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N671UA,1999.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N672AW,2004.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N672DL,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N672UA,1999.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N673AW,,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N673DL,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N673UA,2000.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N674DL,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N674UA,2000.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N675AW,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N675DL,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N675MC,1975.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N675UA,2000.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N676AW,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N676CA,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N676DL,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N676UA,2001.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N677AW,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N677UA,2001.0,Fixed wing multi engine,BOEING,767-322,2,330,,Turbo-fan
+N678AW,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N678CA,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N678DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N679AW,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N679DA,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N68061,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N680AW,2005.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N680DA,1992.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N68159,2001.0,Fixed wing multi engine,BOEING,767-224,2,255,,Turbo-jet
+N68160,2001.0,Fixed wing multi engine,BOEING,767-224,2,255,,Turbo-jet
+N681DA,1993.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N682DA,1993.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N683BR,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N683DA,1993.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N68452,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N68453,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N684DA,1993.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N684WN,1988.0,Fixed wing multi engine,BOEING,737-3TO,2,149,,Turbo-jet
+N685DA,1995.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N685SW,1986.0,Fixed wing multi engine,BOEING,737-3Q8,2,149,,Turbo-fan
+N686DA,1995.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N687DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N687SW,1986.0,Fixed wing multi engine,BOEING,737-3Q8,2,149,,Turbo-fan
+N68801,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N68802,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N68805,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N68807,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N688DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N689DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N69059,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N69063,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N690DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N691CA,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N691WN,1988.0,Fixed wing multi engine,BOEING,737-3G7,2,149,,Turbo-jet
+N692DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N693CA,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N693DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N693SW,1985.0,Fixed wing multi engine,BOEING,737-317,2,149,,Turbo-jet
+N694DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N694SW,1985.0,Fixed wing multi engine,BOEING,737-3T5,2,149,,Turbo-jet
+N695CA,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N695DL,1998.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N696DL,1999.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N697DL,1999.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N697SW,1988.0,Fixed wing multi engine,BOEING,737-3TO,2,149,,Turbo-jet
+N69804,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N69806,2013.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N698DL,1999.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N699DL,1999.0,Fixed wing multi engine,BOEING,757-232,2,178,,Turbo-fan
+N700GS,1997.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N700UW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N701GS,1997.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N701SK,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N701UW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N702SK,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N702TW,1996.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N702UW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N703JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N703SW,1997.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N703TW,1996.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N703UW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N704SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N704US,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N704X,1997.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N705JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N705SK,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N705SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N705TW,1997.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N705UW,,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N706JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N706SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N706TW,1997.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N707EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N707SA,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N707TW,1997.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N708EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N708JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N708SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N708UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N709EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N709JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N709SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N709TW,1997.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N709UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N710EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N710SK,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N710SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N710TW,1997.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N710UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N711HK,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N711MQ,1976.0,Fixed wing multi engine,GULFSTREAM AEROSPACE,G1159B,2,22,,Turbo-jet
+N711UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N711ZX,1997.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N712EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N712JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N712SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N712TW,1997.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N712US,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N713EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N713SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N713TW,1997.0,Fixed wing multi engine,BOEING,757-2Q8,2,178,,Turbo-fan
+N713UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N71411,2002.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N714CB,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N714US,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N715JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N715SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N715UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N716EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N716SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N716UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N717EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N717JL,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N717SA,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N717TW,1999.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N717UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N718EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N718SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N718TW,1999.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N719EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N719SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N720EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N720WN,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N721TW,1999.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N721UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N722EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N722TW,1999.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N722US,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N723EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N723SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N723TW,2000.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N723UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N72405,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N724EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N724SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N724UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N725SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N725UW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N726SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N726SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N727SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N727TW,1999.0,Fixed wing multi engine,BOEING,757-231,2,178,,Turbo-fan
+N728SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N728SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N729JB,,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N729SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N730EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N730SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N730US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N731SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N73251,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73256,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73259,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73270,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73275,2002.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73276,2002.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73278,,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73283,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73291,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N73299,2005.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N732SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N732US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N733SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N733UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N73406,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N73445,2011.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N734SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N735SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N736SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N737JW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N737MQ,1977.0,Fixed wing single engine,CESSNA,172N,1,4,105.0,Reciprocating
+N737US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N73860,2001.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N738CB,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N738EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N738US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N739GB,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N740EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N740SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N740SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N740UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N741EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N741SA,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N741UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N742PS,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N742SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N743SW,1998.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N744EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N744P,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N744SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N745SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N745VJ,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N746JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N746SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N746SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N746UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N747SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N747UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N74856,2004.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N748EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N748SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N748UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N749SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N749US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N750AT,1984.0,Fixed wing multi engine,BOEING,757-212,2,178,,Turbo-jet
+N750EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N750SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N750UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N751EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N751SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N751UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N752EV,,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N752SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N752US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N753EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N753SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N753US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N75410,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N75425,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N75426,,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N75428,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N75429,2008.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N75432,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N75433,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N75435,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N75436,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N754EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N754SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N754UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N755EV,,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N755SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N755US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N756SA,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N756US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N757AT,1984.0,Fixed wing multi engine,BOEING,757-212,2,178,,Turbo-jet
+N757LV,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N757UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N75851,2001.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N75853,2002.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N75854,2002.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N75858,2004.0,Fixed wing multi engine,BOEING,757-324,2,275,,Turbo-fan
+N75861,2001.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N758EV,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N758SW,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N758US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N759EV,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N759GS,1999.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N76054,2000.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N76055,2001.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N76062,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N76064,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N76065,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N760EV,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N760JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N760SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N760SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N760US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N761ND,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N761RR,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N76254,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76265,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76269,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76288,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N762NC,1976.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N762SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N762SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N762US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N763JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N763SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N763US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N764SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N764US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N76502,2006.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76503,,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76504,2006.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76505,,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76508,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76514,,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76515,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76516,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76517,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76519,2009.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76522,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76523,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76526,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76528,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N76529,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N765SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N765US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N766JB,2008.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N766SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N766SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N766US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N767NC,1977.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N767SW,,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N767UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N768JB,2009.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N768SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N768SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N768US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N769SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N769US,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N77012,1999.0,Fixed wing multi engine,BOEING,777-224,2,400,,Turbo-fan
+N7702A,2004.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7704B,2004.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N77066,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N770SA,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N770UW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-112,2,179,,Turbo-fan
+N7713A,2005.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7714B,2004.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N7715E,2005.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N771SA,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N7724A,2009.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N77258,2000.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N77261,2001.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N7726A,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N77295,2005.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N77296,2005.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N772SK,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N772SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N7730A,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7732A,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7734H,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7735A,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7738A,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7739A,2006.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N773SA,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N7740A,2007.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7741C,2007.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N77430,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N77431,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N7744A,2007.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N7746C,2007.0,Fixed wing multi engine,BOEING,737-7BD,2,149,,Turbo-fan
+N774NC,1978.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N774SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N77510,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N77518,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N77520,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N77525,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N77530,2011.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N775JB,2009.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N775SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N776SK,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N776WN,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N777NC,1979.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N777QC,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N777UA,1995.0,Fixed wing multi engine,BOEING,777-222,2,400,,Turbo-fan
+N77865,2002.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N77867,2002.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N77871,2003.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N778SK,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N778SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N779JB,2009.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N779NC,1979.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N779SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N78003,1998.0,Fixed wing multi engine,BOEING,777-224,2,400,,Turbo-fan
+N78013,1999.0,Fixed wing multi engine,BOEING,777-224,2,400,,Turbo-fan
+N78060,2002.0,Fixed wing multi engine,BOEING,767-424ER,2,292,,Turbo-jet
+N780SK,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N780SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N7811F,2001.0,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N7812G,,Fixed wing multi engine,BOEING,737-76N,2,149,,Turbo-fan
+N781WN,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N78285,2004.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N782NC,1980.0,Fixed wing multi engine,MCDONNELL DOUGLAS,DC-9-51,2,139,432.0,Turbo-jet
+N782SA,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N783SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N78438,2009.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N78448,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N784JB,2011.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N784SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N78501,2006.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N78506,2006.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N78509,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N78511,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N78524,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N785SK,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N785SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N786SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N787SA,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N787UA,1997.0,Fixed wing multi engine,BOEING,777-222,2,400,,Turbo-fan
+N78866,2002.0,Fixed wing multi engine,BOEING,757-33N,2,275,,Turbo-jet
+N788SA,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N789JB,2011.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N789SK,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N789SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N790SK,2009.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N790SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N791SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N79279,2003.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N792SW,2000.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N793JB,2011.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N793SA,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N79402,2001.0,Fixed wing multi engine,BOEING,737-924,2,191,,Turbo-fan
+N794JB,2011.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N794SK,2010.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N794SW,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N79521,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N795SK,2010.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N795SW,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N796JB,2012.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N796SW,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N797MX,2001.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N797SK,2010.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2C10,2,80,,Turbo-fan
+N798SW,1998.0,Fixed wing multi engine,BOEING,737-7AD,2,128,,Turbo-jet
+N799SW,,Fixed wing multi engine,BOEING,737-7Q8,2,149,,Turbo-fan
+N800AY,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N801AW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N801AY,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N801UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N802AW,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N802UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N803SK,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N803UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N804AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N804JB,2012.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N804UA,1997.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N805AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N805JB,2012.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N805UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N806JB,2012.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N806UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N807AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N807JB,2012.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N807UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N808UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N809AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N809JB,2012.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N809NW,2005.0,Fixed wing multi engine,AIRBUS,A330-323,2,379,,Turbo-fan
+N809UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N810AW,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N810UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N811UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N812AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N812AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N812UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N813AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N813SK,2006.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N813UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N81449,2012.0,Fixed wing multi engine,BOEING,737-924ER,2,191,,Turbo-fan
+N814AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N814UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N815AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N815UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N816UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N817AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N817UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N818UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N819AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N819AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N819UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N820AS,1997.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N820AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N820AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N820UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N821AW,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N821AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N821JB,2012.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N821UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N822UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N823AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N823UA,1998.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N824AS,1997.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N824AW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N824AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N824UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N825AS,1997.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N825AW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N825AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N825MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N825UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N826AS,1997.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N826AW,,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N826AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N826MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N826UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N827AS,1997.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N827AW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N827AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N827JB,2013.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N827MH,2001.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N827UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N828AS,1997.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N828AW,,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N828JB,2013.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N828MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N828UA,1999.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N829AS,1998.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N829AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N829MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N829UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N8301J,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8302F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8303R,,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8305E,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8306H,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8307K,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8308K,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8309C,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N830AS,1998.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N830AW,,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N830AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N830UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N8310C,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8311Q,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8312C,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8313F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8314L,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8315C,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8316H,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8317M,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8318F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8319F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N831AW,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-132,2,179,,Turbo-jet
+N831AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N831MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N831UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N8320J,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8321D,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8322X,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8323C,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8324A,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8325D,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8326F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8327A,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8328A,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8329B,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N832AS,1998.0,Fixed wing multi engine,CANADAIR,CL-600-2B19,2,55,,Turbo-fan
+N832AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N832UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N833AS,1998.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N833AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N833UA,2000.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N834AS,1998.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N834AW,,Fixed wing multi engine,AIRBUS,A319-132,2,179,,Turbo-fan
+N834AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N834JB,2013.0,Fixed wing multi engine,AIRBUS,A320-232,2,200,,Turbo-fan
+N834MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N834UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N835AS,1998.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N835AW,,Fixed wing multi engine,AIRBUS,A319-132,2,179,,Turbo-fan
+N835AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N835MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N835UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N835VA,2010.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N836AS,1998.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N836AW,2005.0,Fixed wing multi engine,AIRBUS,A319-132,2,179,,Turbo-fan
+N836AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N836UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N836VA,2010.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N837AW,2005.0,Fixed wing multi engine,AIRBUS,A319-132,2,179,,Turbo-fan
+N837MH,2000.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N837UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N837VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N838AW,2005.0,Fixed wing multi engine,AIRBUS,A319-132,2,179,,Turbo-fan
+N838MH,2001.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N838UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N838VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8390A,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N839AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N839MH,2001.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N839UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N839VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8409N,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N840AS,1999.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N840AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N840MH,2001.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N840MQ,1974.0,Fixed wing multi engine,CANADAIR LTD,CF-5D,4,2,,Turbo-jet
+N840UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N840VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8412F,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8416B,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N841AY,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N841MH,2001.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N841UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N841VA,,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8423C,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N842MH,2001.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N842UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N842VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8432A,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N843MH,2002.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N843UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N843VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8444F,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N844MH,2002.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N844UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N844VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8458A,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N845MH,2002.0,Fixed wing multi engine,BOEING,767-432ER,2,300,,Turbo-jet
+N845UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N845VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N846AS,,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N846UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N846VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8475B,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8477R,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N847UA,2001.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N847VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8488D,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N848AS,1999.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N848UA,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N848VA,2011.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8492C,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8495B,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N849UA,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N849VA,2012.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8501F,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8505Q,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8506C,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N850UA,2002.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A319-131,2,179,,Turbo-jet
+N8515F,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8516C,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N851NW,2004.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A330-223,2,379,,Turbo-jet
+N851UA,2002.0,Fixed wing multi engine,AIRBUS,A319-131,2,179,,Turbo-jet
+N851VA,2012.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8525B,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N852UA,2002.0,Fixed wing multi engine,AIRBUS,A319-131,2,179,,Turbo-jet
+N852VA,2012.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8532G,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8533D,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N853UA,2002.0,Fixed wing multi engine,AIRBUS,A319-131,2,179,,Turbo-jet
+N853VA,2012.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8541D,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8543F,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N854NW,2004.0,Fixed wing multi engine,AIRBUS,A330-223,3,379,,Turbo-fan
+N854UA,2002.0,Fixed wing multi engine,AIRBUS,A319-131,2,179,,Turbo-jet
+N854VA,2012.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8554A,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N855UA,2002.0,Fixed wing multi engine,AIRBUS,A319-131,2,179,,Turbo-jet
+N855VA,2012.0,Fixed wing multi engine,AIRBUS,A320-214,2,182,,Turbo-fan
+N8560F,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N856NW,2004.0,Fixed wing multi engine,AIRBUS,A330-223,3,379,,Turbo-fan
+N8577D,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8580A,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8587E,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8588D,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N858AS,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8598B,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N859AS,2000.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8600F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8601C,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8602F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8603F,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8604C,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8604K,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8605E,2012.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8606C,,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8607M,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8608N,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8609A,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8610A,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8611A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8611F,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8612K,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8613K,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8614M,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8615E,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8616C,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8617E,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8618N,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8619F,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8620H,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8621A,2013.0,Fixed wing multi engine,BOEING,737-8H4,2,140,,Turbo-fan
+N8623A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N862DA,1999.0,Fixed wing multi engine,BOEING,777-232,2,400,,Turbo-jet
+N8631E,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N863DA,1999.0,Fixed wing multi engine,BOEING,777-232,2,400,,Turbo-jet
+N8646A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8659B,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N865DA,1999.0,Fixed wing multi engine,BOEING,777-232,2,400,,Turbo-jet
+N8665A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8672A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8673D,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8674A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8683B,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8688C,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8694A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8696C,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8698A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8709A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N870AS,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8710A,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8718E,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N871AS,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8721B,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8733G,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8736A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8745B,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8747B,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N87507,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N87512,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N87513,2008.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N8751D,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N87527,2010.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N87531,2011.0,Fixed wing multi engine,BOEING,737-824,2,149,,Turbo-fan
+N8758D,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8771A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8775A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N877AS,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8783E,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8790A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8794B,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8797A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8800G,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8808H,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N881AS,2001.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8828D,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8836A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8837B,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8839E,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8847A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8855A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8869B,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8877A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8883E,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8884E,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8886A,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8888D,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8891A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8894A,,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8896A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8903A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8905F,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8907A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8908D,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8913A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8914A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8918B,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N891AT,2004.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N8921B,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8923A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8924B,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8928A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N892AT,2004.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N8930E,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8932C,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8933B,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8936A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8938A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N893AT,2004.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N8940E,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8942A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8943A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8944B,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8946A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8948B,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N894AT,2004.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N895AT,2004.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N8960A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8964E,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8965E,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8968E,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8969A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N896AT,2005.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N8970D,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8971A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8972E,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8974C,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8976E,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8977A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8980A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8982A,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N8986B,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N899AT,2005.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N900DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N900EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N900PC,1997.0,Fixed wing multi engine,BOEING,757-26D,2,178,,Turbo-jet
+N900WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N901DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N901WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N901XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N902DA,1994.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N902DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N902FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N902WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N902XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N903DA,1995.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N903DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N903FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N903JB,2013.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N903WN,2007.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N903XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N904DA,1995.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N904DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N904DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N904FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N904WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N904XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N905DA,1995.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N905DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N905DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N905FJ,1986.0,Fixed wing multi engine,AVIONS MARCEL DASSAULT,MYSTERE FALCON 900,3,12,,Turbo-fan
+N905WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N905XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N906AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N906DA,1995.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N906DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N906DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N906FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N906WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N906XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N907DA,1995.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N907DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N907DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N907FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N907JB,2013.0,Fixed wing multi engine,AIRBUS INDUSTRIE,A321-231,2,379,,Turbo-fan
+N907WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N907XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N908DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N908DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N908FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N908WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N908XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N909DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N909DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N909EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N909FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N909WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N909XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N910AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N910DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N910DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N910DN,1995.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N910FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N910FR,2002.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N910WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N910XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N911DA,1995.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N911DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N911DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N911FJ,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N912DE,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N912DL,1987.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N912DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N912FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N912WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N912XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N913DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N913DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N913DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N913EV,2002.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N913FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N913JB,2013.0,Fixed wing multi engine,AIRBUS,A321-231,2,379,,Turbo-fan
+N913WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N913XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N914DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N914DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N914DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N914FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N914WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N914XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N915AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N915DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N915DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N915DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N915FJ,,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N915WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N915XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N916DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N916DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N916DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N916FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N916WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N916XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N917DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N917DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N917DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N917FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N917WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N917XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N918DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N918DH,1998.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N918DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N918FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N918WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N918XJ,2007.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N919AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N919DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N919DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N919DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N919FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N919WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N919XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N920AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N920DE,1993.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N920DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N920DN,,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N920FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N920WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N920XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N921AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N921DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N921DN,,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N921FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N921WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N921XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N922AT,2005.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N922DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N922EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N922FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N922WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N922XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N923AT,2005.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N923DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N923DN,,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N923FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N923WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N923XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N924AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N924DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N924FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N924WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N924XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N925AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N925DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N925FJ,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N925WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N925XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N926AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N926DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N926EV,2003.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N926LR,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N926WN,,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N926XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N927AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N927DA,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N927LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N927WN,,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N927XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N928AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N928DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N928DN,,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N928EV,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N928LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N928WN,,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N928XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N929AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N929DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N929DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N929LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N929WN,2008.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N929XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N930AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N930DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N930LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N930WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N930XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N931DL,1988.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N931LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N931WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N931XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N932AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N932DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N932DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N932LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N932WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N932XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N933AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N933DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N933DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N933LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N933WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N933XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N934AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N934DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N934FJ,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N934WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N934XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N935AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N935DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N935LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N935WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N935XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N936AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N936DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N936WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N936XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N937AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N937DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N937DN,,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N937WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N937XJ,2008.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N938AT,2006.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N938DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N938LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N938WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N939AT,2006.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N939DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N939DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N939LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N939WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N940AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N940DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N940UW,1995.0,Fixed wing multi engine,BOEING,757-2B7,2,178,,Turbo-fan
+N940WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N941DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N941DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N941FR,2005.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N941UW,1995.0,Fixed wing multi engine,BOEING,757-2B7,2,178,,Turbo-fan
+N941WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N942AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N942DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N942LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N942WN,2009.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N943AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N943DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N943DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N943FR,2005.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N943WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N944AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N944DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N944DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N944UW,2006.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N944WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N945AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N945DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N945DN,1998.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N945UW,,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N945WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N946AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N946DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N946UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N946WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N947AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N947DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N947UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N947WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N948AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N948DL,1989.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N948FR,2006.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N948UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N948WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N949AT,1999.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N949DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N949UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N949WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N950AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N950DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N950UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N950WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N951AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N951DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N951FR,2009.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N951UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N951WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N952AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N952DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N952FR,2010.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N952UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N952WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N953AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N953DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N953DN,,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N953FR,2010.0,Fixed wing multi engine,AIRBUS,A319-112,2,100,,Turbo-fan
+N953UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N953WN,2010.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N954AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N954DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N954UW,2007.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N954WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N955AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N955DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N955DN,1996.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N955UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N955WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N956AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N956DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N956DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N956LR,2005.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2D24,2,95,,Turbo-fan
+N956UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N956WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N957AT,2000.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N957DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N957DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-fan
+N957UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N957WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N958AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N958DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N958DN,1997.0,Fixed wing multi engine,MCDONNELL DOUGLAS,MD-90-30,2,142,,Turbo-jet
+N958UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N958WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N959AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N959DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N959DN,1998.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N959UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N959WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N960AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N960DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N960DN,1998.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N960WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N961AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N961DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N961DN,1998.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N961UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N961WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N962DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N962DN,1997.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N962WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N963AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N963DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N963DN,1999.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N963UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N963WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N964AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N964DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N964DN,1999.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N964WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N965AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N965DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N965DN,2000.0,Fixed wing multi engine,BOEING,MD-90-30,2,142,,Turbo-fan
+N965UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N965WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N966AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N966DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N966WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N967AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N967DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N967UW,2008.0,Fixed wing multi engine,EMBRAER,ERJ 190-100 IGW,2,20,,Turbo-fan
+N967WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N968AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N968DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N968WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N969AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N969DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N969WN,2011.0,Fixed wing multi engine,BOEING,737-7H4,2,140,,Turbo-fan
+N970AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N970DL,1990.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N971AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N971DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N972AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N972DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N973DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N974AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N974DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N975AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N975DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N976DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N977AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N977DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N978AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N978DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N978SW,2004.0,Fixed wing multi engine,BOMBARDIER INC,CL-600-2B19,2,55,,Turbo-fan
+N979AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N979DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N980AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N980DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N981AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N981DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N982AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N982DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N983AT,,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N983DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N984DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N985AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N985DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N986AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N986DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N987AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N987DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N988AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N988DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N989AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N989DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N990AT,2001.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N990DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N991AT,,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N991DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N992AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N992DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N993AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N993DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N994AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N994DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N995AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N995DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N996AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N996DL,1991.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N997AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N997DL,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS AIRCRAFT CO,MD-88,2,142,,Turbo-fan
+N998AT,2002.0,Fixed wing multi engine,BOEING,717-200,2,100,,Turbo-fan
+N998DL,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet
+N999DN,1992.0,Fixed wing multi engine,MCDONNELL DOUGLAS CORPORATION,MD-88,2,142,,Turbo-jet

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: uc-python-dl
+name: uc-python
 channels:
     - defaults
     - conda-forge

--- a/notebooks/Setting-the-Stage.ipynb
+++ b/notebooks/Setting-the-Stage.ipynb
@@ -1,0 +1,2430 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Review of Basic Python for Data Science"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Basic Data Types\n",
+    "\n",
+    "\n",
+    "- **integers** (`int`): Whole numbers, positive or negative or zero\n",
+    "\n",
+    "  - e.g. `3`,&nbsp;&nbsp;`0`,&nbsp;&nbsp;`-531`\n",
+    "\n",
+    "\n",
+    "- **floats** (`float`): Decimal numbers\n",
+    "\n",
+    "  - e.g. `3.14`,&nbsp;&nbsp;`0.0004`,&nbsp;&nbsp;`-878.482`\n",
+    "\n",
+    "\n",
+    "- **strings** (`str`): Arbitrary text\n",
+    "\n",
+    "  - e.g. `\"hello\"`,&nbsp;&nbsp;`'my name is ethan'`,&nbsp;&nbsp;`\"\"`\n",
+    "\n",
+    "\n",
+    "- **booleans** (`bool`): Logical values `True` and `False`\n",
+    "\n",
+    "  - `True`,&nbsp;&nbsp;`False` -- that's it\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Container Types\n",
+    "\n",
+    "- Python also has some objects that can \"contain\" others...\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Container Types\n",
+    "\n",
+    "**lists** (`list`): Ordered, 1-dimensional sequences of objects\n",
+    "\n",
+    "  - Elements may be different types of things.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_list = ['a', 'b', 3, 84.51, False]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'b'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Elements can be accessed by index (which counts from 0!):\n",
+    "my_list[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Container Types\n",
+    "\n",
+    "\n",
+    "**dictionaries** (`dict`): Mappings from \"keys\" to \"values\", good for looking up entries by their key\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_dict = {\n",
+    "  'address': '123 Oak Street',\n",
+    "  'city': 'Chicago',\n",
+    "  'bedrooms': 2,\n",
+    "  'bathrooms': 1,\n",
+    "  'rent': 1599.99\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Values can be \"looked up\" by key\n",
+    "my_dict['bedrooms']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Other Types\n",
+    "\n",
+    "- There are many many more data types in Python that you may hear about, but these (along with DataFrames, covered next) are the ones we'll mostly be using.\n",
+    "\n",
+    "- The general term for a Python \"thing\" (of any type) is an **object**.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Pandas\n",
+    "\n",
+    "- The Pandas package is the backbone of data analysis in Python\n",
+    "\n",
+    "- Pandas is all about **DataFrames**, objects that store tabular data\n",
+    "\n",
+    "  - The package was originally developed by financial analysts who wanted to do data analysis in Python, but needed an abstraction similar to DataFrames from the R language to do so.\n",
+    "\n",
+    "\n",
+    "- The funny name is short for **Pan**el **Da**ta\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# DataFrames -- Basics\n",
+    "\n",
+    "- DataFrames are tabular data\n",
+    "  - Think: DataFrames in R, tables in SQL, Datasets in SAS\n",
+    "\n",
+    "\n",
+    "- DataFrames have **column names** and **row indices**\n",
+    "\n",
+    "- We'll use this DataFrame of planes for many of our examples in this section.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "planes_df = pd.read_csv('../data/planes.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tailnum</th>\n",
+       "      <th>year</th>\n",
+       "      <th>type</th>\n",
+       "      <th>manufacturer</th>\n",
+       "      <th>model</th>\n",
+       "      <th>engines</th>\n",
+       "      <th>seats</th>\n",
+       "      <th>speed</th>\n",
+       "      <th>engine</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>N10156</td>\n",
+       "      <td>2004.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>EMBRAER</td>\n",
+       "      <td>EMB-145XR</td>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>N102UW</td>\n",
+       "      <td>1998.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>N103US</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>N104UW</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>N10575</td>\n",
+       "      <td>2002.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>EMBRAER</td>\n",
+       "      <td>EMB-145LR</td>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  tailnum    year                     type      manufacturer      model  \\\n",
+       "0  N10156  2004.0  Fixed wing multi engine           EMBRAER  EMB-145XR   \n",
+       "1  N102UW  1998.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "2  N103US  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "3  N104UW  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "4  N10575  2002.0  Fixed wing multi engine           EMBRAER  EMB-145LR   \n",
+       "\n",
+       "   engines  seats  speed     engine  \n",
+       "0        2     55    NaN  Turbo-fan  \n",
+       "1        2    182    NaN  Turbo-fan  \n",
+       "2        2    182    NaN  Turbo-fan  \n",
+       "3        2    182    NaN  Turbo-fan  \n",
+       "4        2     55    NaN  Turbo-fan  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# DataFrames -- Importing Data\n",
+    "\n",
+    "- Easy to read in data from common formats (CSV, JSON, SQL databases)\n",
+    "\n",
+    "- `pd.read_csv`, `pd.read_json`, `pd.read_excel`, `pd.read_sql` are several of the many options for importing data.\n",
+    "\n",
+    "  - When reading from a flat file, just pass in the path to the file.\n",
+    "\n",
+    "```python\n",
+    "df = pd.read_csv('data/my_data.csv')\n",
+    "\n",
+    "\n",
+    "df = pd.read_json('data/my_data.json')\n",
+    "\n",
+    "\n",
+    "df = pd.read_excel('data/my_spreadsheet.xlsx')\n",
+    "\n",
+    "\n",
+    "# SQL tables require first creating a connection to the database, which varies by type of DB\n",
+    "df = pd.read_sql('my_table', db_connection) \n",
+    "```\n",
+    "\n",
+    "- Other formats Pandas can read: parquet, fixed-width text, feather, Stata, SAS, pickle, HDF5\n",
+    "\n",
+    "- Also can read from the web with **`pd.read_html`**\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# DataFrames -- Inspecting Data\n",
+    "\n",
+    "`df.head()` is usually the place to start -- returns the first 5 rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tailnum</th>\n",
+       "      <th>year</th>\n",
+       "      <th>type</th>\n",
+       "      <th>manufacturer</th>\n",
+       "      <th>model</th>\n",
+       "      <th>engines</th>\n",
+       "      <th>seats</th>\n",
+       "      <th>speed</th>\n",
+       "      <th>engine</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>N10156</td>\n",
+       "      <td>2004.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>EMBRAER</td>\n",
+       "      <td>EMB-145XR</td>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>N102UW</td>\n",
+       "      <td>1998.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>N103US</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>N104UW</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>N10575</td>\n",
+       "      <td>2002.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>EMBRAER</td>\n",
+       "      <td>EMB-145LR</td>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  tailnum    year                     type      manufacturer      model  \\\n",
+       "0  N10156  2004.0  Fixed wing multi engine           EMBRAER  EMB-145XR   \n",
+       "1  N102UW  1998.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "2  N103US  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "3  N104UW  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "4  N10575  2002.0  Fixed wing multi engine           EMBRAER  EMB-145LR   \n",
+       "\n",
+       "   engines  seats  speed     engine  \n",
+       "0        2     55    NaN  Turbo-fan  \n",
+       "1        2    182    NaN  Turbo-fan  \n",
+       "2        2    182    NaN  Turbo-fan  \n",
+       "3        2    182    NaN  Turbo-fan  \n",
+       "4        2     55    NaN  Turbo-fan  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# DataFrames -- Inspecting Data\n",
+    "\n",
+    "Other options..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3322, 9)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.shape # Return (n_rows, n_columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['tailnum', 'year', 'type', 'manufacturer', 'model', 'engines', 'seats',\n",
+       "       'speed', 'engine'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.columns # Return column names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# DataFrames -- Inspecting Data\n",
+    "\n",
+    "`df.info()` gives a comprehensive overview, ideal when working interactively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 3322 entries, 0 to 3321\n",
+      "Data columns (total 9 columns):\n",
+      " #   Column        Non-Null Count  Dtype  \n",
+      "---  ------        --------------  -----  \n",
+      " 0   tailnum       3322 non-null   object \n",
+      " 1   year          3252 non-null   float64\n",
+      " 2   type          3322 non-null   object \n",
+      " 3   manufacturer  3322 non-null   object \n",
+      " 4   model         3322 non-null   object \n",
+      " 5   engines       3322 non-null   int64  \n",
+      " 6   seats         3322 non-null   int64  \n",
+      " 7   speed         23 non-null     float64\n",
+      " 8   engine        3322 non-null   object \n",
+      "dtypes: float64(2), int64(2), object(5)\n",
+      "memory usage: 233.7+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "planes_df.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# DataFrames -- Exporting Data\n",
+    "\n",
+    "- Pandas can save data in most of the formats it supports importing from.\n",
+    "\n",
+    "- Instead of `pd.read_FILETYPE`, it's usually `df.to_FILETYPE`\n",
+    "\n",
+    "```python\n",
+    "df.to_csv('data/my_data.csv')\n",
+    "\n",
+    "\n",
+    "df.to_json('data/my_data.json')\n",
+    "\n",
+    "\n",
+    "# Again, you need an existing database connection to work with SQL.\n",
+    "df.to_sql('my_table', db_connection)\n",
+    "```\n",
+    "\n",
+    "\n",
+    "- We'll probably mostly save data in CSVs in this course, for simplicity.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Subsetting Data\n",
+    "\n",
+    "- Before you do much else, you need to be able to get at pieces of a DataFrame that you're interested in.\n",
+    "\n",
+    "- This usually means limiting to certain columns, to certain rows, or both at the same time.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Selecting\n",
+    "\n",
+    "- Subsetting data by its columns is often called **selecting**\n",
+    "\n",
+    "  - You might say \"select the name column from the data\"\n",
+    "\n",
+    "- The syntax to select a single column is `df[column_name]`\n",
+    "\n",
+    "  - This returns a **series** object, a 1-dimensional Pandas object\n",
+    "\n",
+    "  - Series are a lot like Python lists, except all the data in them is usually of the same type\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Selecting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0        55\n",
+       "1       182\n",
+       "2       182\n",
+       "3       182\n",
+       "4        55\n",
+       "       ... \n",
+       "3317    100\n",
+       "3318    142\n",
+       "3319    100\n",
+       "3320    142\n",
+       "3321    142\n",
+       "Name: seats, Length: 3322, dtype: int64"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df['seats']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "- Remember, this isn't a DataFrame, it's a Series\n",
+    "\n",
+    "  - One way to tell is the bottom line, which says the name of the column, the length (number of entries), and the type of the elements in it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Selecting\n",
+    "\n",
+    "- Selecting multiple columns is done with double brackets\n",
+    "\n",
+    "  - The inner brackets indicate to Pandas that you're passing a *list of columns*\n",
+    "\n",
+    "\n",
+    "- Using double brackets returns a **DataFrame**, not a Series\n",
+    "  \n",
+    "  - You can even use double brackets with a single column if you don't want a Series\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>seats</th>\n",
+       "      <th>tailnum</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>55</td>\n",
+       "      <td>N10156</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N102UW</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N103US</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N104UW</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>55</td>\n",
+       "      <td>N10575</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3317</th>\n",
+       "      <td>100</td>\n",
+       "      <td>N997AT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3318</th>\n",
+       "      <td>142</td>\n",
+       "      <td>N997DL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3319</th>\n",
+       "      <td>100</td>\n",
+       "      <td>N998AT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3320</th>\n",
+       "      <td>142</td>\n",
+       "      <td>N998DL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3321</th>\n",
+       "      <td>142</td>\n",
+       "      <td>N999DN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3322 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      seats tailnum\n",
+       "0        55  N10156\n",
+       "1       182  N102UW\n",
+       "2       182  N103US\n",
+       "3       182  N104UW\n",
+       "4        55  N10575\n",
+       "...     ...     ...\n",
+       "3317    100  N997AT\n",
+       "3318    142  N997DL\n",
+       "3319    100  N998AT\n",
+       "3320    142  N998DL\n",
+       "3321    142  N999DN\n",
+       "\n",
+       "[3322 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df[['seats', 'tailnum']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "`['seats', 'tailnum']` is actually a list we pass into `planes_df[]`, which is why we get a 2-dimensional object (a DataFrame) back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>seats</th>\n",
+       "      <th>tailnum</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>55</td>\n",
+       "      <td>N10156</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N102UW</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N103US</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N104UW</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>55</td>\n",
+       "      <td>N10575</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3317</th>\n",
+       "      <td>100</td>\n",
+       "      <td>N997AT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3318</th>\n",
+       "      <td>142</td>\n",
+       "      <td>N997DL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3319</th>\n",
+       "      <td>100</td>\n",
+       "      <td>N998AT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3320</th>\n",
+       "      <td>142</td>\n",
+       "      <td>N998DL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3321</th>\n",
+       "      <td>142</td>\n",
+       "      <td>N999DN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3322 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      seats tailnum\n",
+       "0        55  N10156\n",
+       "1       182  N102UW\n",
+       "2       182  N103US\n",
+       "3       182  N104UW\n",
+       "4        55  N10575\n",
+       "...     ...     ...\n",
+       "3317    100  N997AT\n",
+       "3318    142  N997DL\n",
+       "3319    100  N998AT\n",
+       "3320    142  N998DL\n",
+       "3321    142  N999DN\n",
+       "\n",
+       "[3322 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "columns = ['seats', 'tailnum']\n",
+    "planes_df[columns]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Indexing\n",
+    "\n",
+    "- \"Indexing\" is the word we use for subsetting rows based on their location or row label.\n",
+    "\n",
+    "- Most things in Python index from 0.\n",
+    "\n",
+    "  - That means an sequence with 3 elements would label them #0, #1, and #2.\n",
+    "  \n",
+    "\n",
+    "- DataFrames have row indexes, as we've discussed before.\n",
+    "\n",
+    "  - You can think of them as row labels.\n",
+    "\n",
+    "  - By default, they're just integers from 0 to (number_of_rows - 1).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Indexing\n",
+    "\n",
+    "- Here, the indices are 0-4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tailnum</th>\n",
+       "      <th>year</th>\n",
+       "      <th>type</th>\n",
+       "      <th>manufacturer</th>\n",
+       "      <th>model</th>\n",
+       "      <th>engines</th>\n",
+       "      <th>seats</th>\n",
+       "      <th>speed</th>\n",
+       "      <th>engine</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>N10156</td>\n",
+       "      <td>2004.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>EMBRAER</td>\n",
+       "      <td>EMB-145XR</td>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>N102UW</td>\n",
+       "      <td>1998.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>N103US</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>N104UW</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>N10575</td>\n",
+       "      <td>2002.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>EMBRAER</td>\n",
+       "      <td>EMB-145LR</td>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  tailnum    year                     type      manufacturer      model  \\\n",
+       "0  N10156  2004.0  Fixed wing multi engine           EMBRAER  EMB-145XR   \n",
+       "1  N102UW  1998.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "2  N103US  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "3  N104UW  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "4  N10575  2002.0  Fixed wing multi engine           EMBRAER  EMB-145LR   \n",
+       "\n",
+       "   engines  seats  speed     engine  \n",
+       "0        2     55    NaN  Turbo-fan  \n",
+       "1        2    182    NaN  Turbo-fan  \n",
+       "2        2    182    NaN  Turbo-fan  \n",
+       "3        2    182    NaN  Turbo-fan  \n",
+       "4        2     55    NaN  Turbo-fan  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Indexing\n",
+    "\n",
+    "- Indices can be selected using `df.loc` and brackets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tailnum                          N103US\n",
+       "year                             1999.0\n",
+       "type            Fixed wing multi engine\n",
+       "manufacturer           AIRBUS INDUSTRIE\n",
+       "model                          A320-214\n",
+       "engines                               2\n",
+       "seats                               182\n",
+       "speed                               NaN\n",
+       "engine                        Turbo-fan\n",
+       "Name: 2, dtype: object"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.loc[2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "- Like selecting a single column, indexing a single row returns a **Series**, not a DataFrame.\n",
+    "\n",
+    "  - Because, again, it's a 1-dimensional object."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Indexing\n",
+    "\n",
+    "- DataFrames can also be indexed with a *range*, instead of a single row index.\n",
+    "\n",
+    "- This uses the same `df.loc` syntax, except a range is passed\n",
+    "  \n",
+    "  - `df.loc[starting_index:ending_index]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tailnum</th>\n",
+       "      <th>year</th>\n",
+       "      <th>type</th>\n",
+       "      <th>manufacturer</th>\n",
+       "      <th>model</th>\n",
+       "      <th>engines</th>\n",
+       "      <th>seats</th>\n",
+       "      <th>speed</th>\n",
+       "      <th>engine</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>N104UW</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>N10575</td>\n",
+       "      <td>2002.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>EMBRAER</td>\n",
+       "      <td>EMB-145LR</td>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>N105UW</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>N107US</td>\n",
+       "      <td>1999.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A320-214</td>\n",
+       "      <td>2</td>\n",
+       "      <td>182</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  tailnum    year                     type      manufacturer      model  \\\n",
+       "3  N104UW  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "4  N10575  2002.0  Fixed wing multi engine           EMBRAER  EMB-145LR   \n",
+       "5  N105UW  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "6  N107US  1999.0  Fixed wing multi engine  AIRBUS INDUSTRIE   A320-214   \n",
+       "\n",
+       "   engines  seats  speed     engine  \n",
+       "3        2    182    NaN  Turbo-fan  \n",
+       "4        2     55    NaN  Turbo-fan  \n",
+       "5        2    182    NaN  Turbo-fan  \n",
+       "6        2    182    NaN  Turbo-fan  "
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.loc[3:6]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Combining Selecting and Indexing\n",
+    "\n",
+    "- You can select columns and index rows all at once using `df.loc[row_index, columns]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>seats</th>\n",
+       "      <th>tailnum</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N104UW</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>55</td>\n",
+       "      <td>N10575</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N105UW</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>182</td>\n",
+       "      <td>N107US</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   seats tailnum\n",
+       "3    182  N104UW\n",
+       "4     55  N10575\n",
+       "5    182  N105UW\n",
+       "6    182  N107US"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Row indices 3-6, columns \"seats\" and \"tailnum\"\n",
+    "planes_df.loc[3:6, ['seats', 'tailnum']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Combining Selecting and Indexing\n",
+    "\n",
+    "| Goal | Syntax |\n",
+    "|:- |:- | \n",
+    "| Select columns | `df[columns]` |\n",
+    "| Index rows | `df.loc[row_indices]` |\n",
+    "| Select columns *and* index rows | `df.loc[row_indices, columns]` |\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Filtering\n",
+    "\n",
+    "- *Filtering* means limiting rows based on a condition of the data\n",
+    "\n",
+    "  - e.g. \"all rows where the number of engines is greater than 2\"\n",
+    "  \n",
+    "\n",
+    "- This is also done with `df.loc`, but you pass in an expression describing which rows to keep.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tailnum</th>\n",
+       "      <th>year</th>\n",
+       "      <th>type</th>\n",
+       "      <th>manufacturer</th>\n",
+       "      <th>model</th>\n",
+       "      <th>engines</th>\n",
+       "      <th>seats</th>\n",
+       "      <th>speed</th>\n",
+       "      <th>engine</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>603</th>\n",
+       "      <td>N281AT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS INDUSTRIE</td>\n",
+       "      <td>A340-313</td>\n",
+       "      <td>4</td>\n",
+       "      <td>375</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1037</th>\n",
+       "      <td>N381AA</td>\n",
+       "      <td>1956.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>DOUGLAS</td>\n",
+       "      <td>DC-7BF</td>\n",
+       "      <td>4</td>\n",
+       "      <td>102</td>\n",
+       "      <td>232.0</td>\n",
+       "      <td>Reciprocating</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2109</th>\n",
+       "      <td>N670US</td>\n",
+       "      <td>1990.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>BOEING</td>\n",
+       "      <td>747-451</td>\n",
+       "      <td>4</td>\n",
+       "      <td>450</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2706</th>\n",
+       "      <td>N840MQ</td>\n",
+       "      <td>1974.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>CANADAIR LTD</td>\n",
+       "      <td>CF-5D</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2764</th>\n",
+       "      <td>N854NW</td>\n",
+       "      <td>2004.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS</td>\n",
+       "      <td>A330-223</td>\n",
+       "      <td>3</td>\n",
+       "      <td>379</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2771</th>\n",
+       "      <td>N856NW</td>\n",
+       "      <td>2004.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AIRBUS</td>\n",
+       "      <td>A330-223</td>\n",
+       "      <td>3</td>\n",
+       "      <td>379</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2931</th>\n",
+       "      <td>N905FJ</td>\n",
+       "      <td>1986.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>AVIONS MARCEL DASSAULT</td>\n",
+       "      <td>MYSTERE FALCON 900</td>\n",
+       "      <td>3</td>\n",
+       "      <td>12</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     tailnum    year                     type            manufacturer  \\\n",
+       "603   N281AT     NaN  Fixed wing multi engine        AIRBUS INDUSTRIE   \n",
+       "1037  N381AA  1956.0  Fixed wing multi engine                 DOUGLAS   \n",
+       "2109  N670US  1990.0  Fixed wing multi engine                  BOEING   \n",
+       "2706  N840MQ  1974.0  Fixed wing multi engine            CANADAIR LTD   \n",
+       "2764  N854NW  2004.0  Fixed wing multi engine                  AIRBUS   \n",
+       "2771  N856NW  2004.0  Fixed wing multi engine                  AIRBUS   \n",
+       "2931  N905FJ  1986.0  Fixed wing multi engine  AVIONS MARCEL DASSAULT   \n",
+       "\n",
+       "                   model  engines  seats  speed         engine  \n",
+       "603             A340-313        4    375    NaN      Turbo-jet  \n",
+       "1037              DC-7BF        4    102  232.0  Reciprocating  \n",
+       "2109             747-451        4    450    NaN      Turbo-jet  \n",
+       "2706               CF-5D        4      2    NaN      Turbo-jet  \n",
+       "2764            A330-223        3    379    NaN      Turbo-fan  \n",
+       "2771            A330-223        3    379    NaN      Turbo-fan  \n",
+       "2931  MYSTERE FALCON 900        3     12    NaN      Turbo-fan  "
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This syntax is a little clunky; the DataFrame name is specified twice.\n",
+    "planes_df.loc[planes_df['engines'] > 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tailnum</th>\n",
+       "      <th>year</th>\n",
+       "      <th>type</th>\n",
+       "      <th>manufacturer</th>\n",
+       "      <th>model</th>\n",
+       "      <th>engines</th>\n",
+       "      <th>seats</th>\n",
+       "      <th>speed</th>\n",
+       "      <th>engine</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1813</th>\n",
+       "      <td>N600TR</td>\n",
+       "      <td>1979.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2131</th>\n",
+       "      <td>N675MC</td>\n",
+       "      <td>1975.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2402</th>\n",
+       "      <td>N762NC</td>\n",
+       "      <td>1976.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2432</th>\n",
+       "      <td>N767NC</td>\n",
+       "      <td>1977.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2472</th>\n",
+       "      <td>N774NC</td>\n",
+       "      <td>1978.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2483</th>\n",
+       "      <td>N777NC</td>\n",
+       "      <td>1979.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2492</th>\n",
+       "      <td>N779NC</td>\n",
+       "      <td>1979.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2503</th>\n",
+       "      <td>N782NC</td>\n",
+       "      <td>1980.0</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>MCDONNELL DOUGLAS</td>\n",
+       "      <td>DC-9-51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>139</td>\n",
+       "      <td>432.0</td>\n",
+       "      <td>Turbo-jet</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     tailnum    year                     type       manufacturer    model  \\\n",
+       "1813  N600TR  1979.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "2131  N675MC  1975.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "2402  N762NC  1976.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "2432  N767NC  1977.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "2472  N774NC  1978.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "2483  N777NC  1979.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "2492  N779NC  1979.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "2503  N782NC  1980.0  Fixed wing multi engine  MCDONNELL DOUGLAS  DC-9-51   \n",
+       "\n",
+       "      engines  seats  speed     engine  \n",
+       "1813        2    139  432.0  Turbo-jet  \n",
+       "2131        2    139  432.0  Turbo-jet  \n",
+       "2402        2    139  432.0  Turbo-jet  \n",
+       "2432        2    139  432.0  Turbo-jet  \n",
+       "2472        2    139  432.0  Turbo-jet  \n",
+       "2483        2    139  432.0  Turbo-jet  \n",
+       "2492        2    139  432.0  Turbo-jet  \n",
+       "2503        2    139  432.0  Turbo-jet  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.loc[planes_df['seats'] == 139]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Combining Selecting and Filtering\n",
+    "\n",
+    "- Like indexing, filtering can be combined with selecting in the `.loc` brackets.\n",
+    "\n",
+    "  - `df.loc[row_filter, columns]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>seats</th>\n",
+       "      <th>tailnum</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1813</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N600TR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2131</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N675MC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2402</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N762NC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2432</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N767NC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2472</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N774NC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2483</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N777NC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2492</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N779NC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2503</th>\n",
+       "      <td>139</td>\n",
+       "      <td>N782NC</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      seats tailnum\n",
+       "1813    139  N600TR\n",
+       "2131    139  N675MC\n",
+       "2402    139  N762NC\n",
+       "2432    139  N767NC\n",
+       "2472    139  N774NC\n",
+       "2483    139  N777NC\n",
+       "2492    139  N779NC\n",
+       "2503    139  N782NC"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.loc[planes_df['seats'] == 139, ['seats', 'tailnum']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Combining Selecting and Filtering\n",
+    "\n",
+    "So we can update our syntax chart...\n",
+    "\n",
+    "| Goal | Syntax |\n",
+    "|:- |:- | \n",
+    "| Select columns | `df[columns]` |\n",
+    "| Index rows | `df.loc[row_indices]` |\n",
+    "| Select columns *and* index rows | `df.loc[row_indices, columns]` |\n",
+    "| Filter rows | `df.loc[filter_condition]` |\n",
+    "| Select columns *and* filter rows | `df.loc[filter_condition, columns]` |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "- Generally:\n",
+    "\n",
+    "  - Columns: `df[columns]`\n",
+    "\n",
+    "  - Rows: `df.loc[rows]`\n",
+    "\n",
+    "  - Both: `df.loc[rows, columns]`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# DataFrame-level Summaries\n",
+    "\n",
+    "- You can get quick summaries of all numeric columns in a DataFrame using `df.describe()`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>year</th>\n",
+       "      <th>engines</th>\n",
+       "      <th>seats</th>\n",
+       "      <th>speed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>3252.000000</td>\n",
+       "      <td>3322.000000</td>\n",
+       "      <td>3322.000000</td>\n",
+       "      <td>23.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>2000.484010</td>\n",
+       "      <td>1.995184</td>\n",
+       "      <td>154.316376</td>\n",
+       "      <td>236.782609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>7.193425</td>\n",
+       "      <td>0.117593</td>\n",
+       "      <td>73.654974</td>\n",
+       "      <td>149.759794</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>1956.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>90.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>1997.000000</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>140.000000</td>\n",
+       "      <td>107.500000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>2001.000000</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>149.000000</td>\n",
+       "      <td>162.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>2005.000000</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>182.000000</td>\n",
+       "      <td>432.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>2013.000000</td>\n",
+       "      <td>4.000000</td>\n",
+       "      <td>450.000000</td>\n",
+       "      <td>432.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              year      engines        seats       speed\n",
+       "count  3252.000000  3322.000000  3322.000000   23.000000\n",
+       "mean   2000.484010     1.995184   154.316376  236.782609\n",
+       "std       7.193425     0.117593    73.654974  149.759794\n",
+       "min    1956.000000     1.000000     2.000000   90.000000\n",
+       "25%    1997.000000     2.000000   140.000000  107.500000\n",
+       "50%    2001.000000     2.000000   149.000000  162.000000\n",
+       "75%    2005.000000     2.000000   182.000000  432.000000\n",
+       "max    2013.000000     4.000000   450.000000  432.000000"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "- If you want summaries of string/categorical columns instead, use `df.describe(include='object')`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tailnum</th>\n",
+       "      <th>type</th>\n",
+       "      <th>manufacturer</th>\n",
+       "      <th>model</th>\n",
+       "      <th>engine</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>3322</td>\n",
+       "      <td>3322</td>\n",
+       "      <td>3322</td>\n",
+       "      <td>3322</td>\n",
+       "      <td>3322</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>unique</th>\n",
+       "      <td>3322</td>\n",
+       "      <td>3</td>\n",
+       "      <td>35</td>\n",
+       "      <td>127</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>top</th>\n",
+       "      <td>N956AT</td>\n",
+       "      <td>Fixed wing multi engine</td>\n",
+       "      <td>BOEING</td>\n",
+       "      <td>737-7H4</td>\n",
+       "      <td>Turbo-fan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>freq</th>\n",
+       "      <td>1</td>\n",
+       "      <td>3292</td>\n",
+       "      <td>1630</td>\n",
+       "      <td>361</td>\n",
+       "      <td>2750</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       tailnum                     type manufacturer    model     engine\n",
+       "count     3322                     3322         3322     3322       3322\n",
+       "unique    3322                        3           35      127          6\n",
+       "top     N956AT  Fixed wing multi engine       BOEING  737-7H4  Turbo-fan\n",
+       "freq         1                     3292         1630      361       2750"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df.describe(include='object')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Column-level Summaries\n",
+    "\n",
+    "- Series (remember, individual columns are Series objects) offer lots of summary options.\n",
+    "\n",
+    "- Usually they're invoked as `df[column].SUMMARY()` and return a single, scalar value.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Column-level Numeric Summaries\n",
+    "\n",
+    "- `df[column].mean()`\n",
+    "\n",
+    "- `df[column].max()`\n",
+    "\n",
+    "- `df[column].min()`\n",
+    "\n",
+    "- `df[column].quantile(q=0.5) # Median`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1956.0"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df['year'].min()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "\n",
+    "\n",
+    "# Column-level Categorical Summaries\n",
+    "\n",
+    "- `df[column].nunique() # Number of unique values`\n",
+    "\n",
+    "- `df[column].value_counts() # Number of occurrences of each value, descending`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df['engine'].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Fixed wing multi engine     3292\n",
+       "Fixed wing single engine      25\n",
+       "Rotorcraft                     5\n",
+       "Name: type, dtype: int64"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "planes_df['type'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Note that `value_counts` is an exception to the rule -- it doesn't return a single number, but instead a *Series*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Questions"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "uc-python",
+   "language": "python",
+   "name": "uc-python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/generate_slides.sh
+++ b/scripts/generate_slides.sh
@@ -11,5 +11,5 @@ cd notebooks
 cp -r images ../slides
 # Match all notebook files with content.
 for file in *-*.ipynb; do
-    jupyter nbconvert --to slides $file --reveal-prefix https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.3.0 --output-dir=../slides
+    jupyter nbconvert --to slides $file --output-dir=../slides
 done


### PR DESCRIPTION
For my web scraping course, I had to create a single module reviewing almost all the data wrangling content for our first two classes. I ported that into a notebook and have added it. We don't have to use it, but if we feel the need for a review before jumping into things, this would probably take about one hour if covered quickly. It could maybe replace "Setting the Stage", though it definitely needs more than 30 minutes.

I also fixed the script that converts notebooks to slides. I don't know if you use that, but running `bash scripts/generate_slides.sh` should work for you – that creates a `slides/` directory with a file for each notebook.