### PR TITLE
Fix bug in script and add makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+slides: slides/.finished
+slides/.finished: $(wildcard notebooks/**/*)
+	bash scripts/generate_slides.sh
+	touch slides/.finished
+
+clean:
+	rm -rf slides/

--- a/scripts/generate_slides.sh
+++ b/scripts/generate_slides.sh
@@ -8,7 +8,8 @@ fi
 # We must be *in* the notebook folder for relative links (to eg images) to work
 # correctly..
 cd notebooks
-cp -r images ../slides
+mkdir -p ../slides/images/
+cp -a ./images/* ../slides/images/
 # Match all notebook files with content.
 for file in *-*.ipynb; do
     jupyter nbconvert --to slides $file --output-dir=../slides


### PR DESCRIPTION
I found that on my M1 Mac, the `generate_slides` script didn't work correctly (it copied images right into `./slides/` instead of into `./slides/images/`), so I rectified that and along with it, threw in a little Makefile because I know how much you love Makefiles.

It should make building slides easier, though. Simply: `make slides`